### PR TITLE
Fixes for Issue #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - '6'
+  - '4'

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@
 
 ## Install 
 
-Via [Node.js](https://nodejs.org) run the following:
-```bash
+```ENSURE YOU'VE NODEJS VERSION >=4 INSTALLED, THEN RUN THE FOLLOWING :```
+
+```
 $ npm i --global pagespeed-score-cli
+```
+__OR__
+```
+$ sudo npm i --global pagespeed-score-cli
 ```
 
 ## Usage

--- a/cli.js
+++ b/cli.js
@@ -2,14 +2,14 @@
 
 'use strict';
 
-const pagespeed = require('./pagespeed');
+const dns = require('dns');
 const chalk = require('chalk');
 const isURL = require('is-url');
-const dns = require('dns');
 const ora = require('ora');
 const argv = require('minimist')(process.argv.slice(2));
 const logUpdate = require('log-update');
 const logSymbols = require('log-symbols');
+const pagespeed = require('./pagespeed');
 
 let url = argv._;
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,11 @@
   "bin": {
     "pagespeed-score": "cli.js"
   },
+  "engines": {
+  	"node": ">=4"
+  },
   "scripts": {
-    "test": "ava test.js"
+    "test": "xo && ava"
   },
   "repository": {
     "type": "git",
@@ -25,10 +28,6 @@
     "website",
     "score"
   ],
-  "bugs": {
-    "url": "https://github.com/cauealves/pagespeed-score-cli/issues"
-  },
-  "homepage": "https://github.com/cauealves/pagespeed-score-cli#readme",
   "dependencies": {
     "chalk": "^1.1.3",
     "dns": "^0.2.2",
@@ -37,6 +36,15 @@
     "meow": "^3.7.0",
     "minimist": "^1.2.0",
     "node-fetch": "^1.5.3",
-    "ora": "^0.2.3"
-  }
+    "ora": "^0.2.3",
+    "is-url": "*"
+  },
+  "devDependencies": {
+  	"xo": "*",
+  	"ava": "*"
+  },
+  "bugs": {
+  	"url": "https://github.com/cauealves/pagespeed-score-cli/issues"
+  },
+  "homepage": "https://github.com/cauealves/pagespeed-score-cli#readme"
 }

--- a/pagespeed.js
+++ b/pagespeed.js
@@ -7,14 +7,14 @@ const fetch = require('node-fetch');
 const API_URL = 'https://www.googleapis.com/pagespeedonline/v2/runPagespeed?';
 
 module.exports = function (url, strategy, locale, filterThirdParty) {
-  let query = [
-    'url=' + url,
-    'strategy=' + strategy,
-    'locale=' + locale,
-    'filter_third_party_resources=' + filterThirdParty
-  ].join('&');
-  
-  return fetch(API_URL + query).then((response) => {
-    return response.json();
-  });
+	let query = [
+		'url=' + url,
+		'strategy=' + strategy,
+		'locale=' + locale,
+		'filter_third_party_resources=' + filterThirdParty
+	].join('&');
+
+	return fetch(API_URL + query).then((response) => {
+		return response.json();
+	});
 };

--- a/test.js
+++ b/test.js
@@ -1,0 +1,13 @@
+import childProcess from 'child_process';
+import test from 'ava';
+
+test.cb(t => {
+	const cp = childProcess.spawn('./cli.js', {stdio: 'inherit'});
+
+	cp.on('error', t.ifError);
+
+	cp.on('close', code => {
+		t.is(code, 1);
+		t.end();
+	});
+});


### PR DESCRIPTION
Here is the issue - https://github.com/cauealves/pagespeed-score-cli/issues/3

List of things removed - 
- `useless spaces`
- `useless modules`
- `ora style`

List of things added -
- `check connection` : Just in case you are offline.
- `usages` : Show usages in console if no argument is supplied ( currently, if you do `pagespeed-score` then too it will show you the process but without giving any result )
- `url validation` - this tool requires `http://` and `https://` before domain name to complete the process, but currently if you run - `pagespeed-score google.com` then you'll not get any result. 
  So, this feature check whether the url is valid or not and handle them accordingly. 

List of things improved -
- `starting messages` https://github.com/cauealves/pagespeed-score-cli/issues/2
- `ora style and processes colors` https://github.com/cauealves/pagespeed-score-cli/issues/2
- `output along with status and total score`  https://github.com/cauealves/pagespeed-score-cli/issues/2

Extra : 

**Test for `pagespeed-score-cli`**  https://github.com/cauealves/pagespeed-score-cli/issues/1

**PS :** After committing all those changes, now, the tool is working without any problem. :)
